### PR TITLE
Enhance Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,11 @@
 language: php
 
-matrix:
-  include:
-    - php: 7.0
-      env:
-        - PHPUNIT_VERSION=6.*
-    - php: 7.1
-      env:
-        - PHPUNIT_VERSION=6.*
-    - php: 7.1
-      env:
-        - PHPUNIT_VERSION=7.*
-    - php: 7.2
-      env:
-        - PHPUNIT_VERSION=6.*
-    - php: 7.2
-      env:
-        - PHPUNIT_VERSION=7.*
-    - php: 7.2
-      env:
-        - PHPUNIT_VERSION=8.*
-    - php: 7.3
-      env:
-        - PHPUNIT_VERSION=6.*
-    - php: 7.3
-      env:
-        - PHPUNIT_VERSION=7.*
-    - php: 7.3
-      env:
-        - PHPUNIT_VERSION=8.*
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 install:
-  - composer require phpunit/phpunit:$PHPUNIT_VERSION;
+  - composer install
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "phpunit/phpunit": ">=6.5"
+        "php": ">=7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Changed log
- Move `phpunit/phpunit` definition to `require-dev` block in `composer.json`.
- Using the `composer install` command can let `composer` find and install current PHPUnit versions.
And remove the unused `PHPUNIT_VERSION` environment variables.
- This forked PR Travis CI build is available [here](https://travis-ci.org/open-source-contributions/doubles/builds/575159147).